### PR TITLE
Fix missing App export

### DIFF
--- a/2ndp/my2nd/src/App.tsx
+++ b/2ndp/my2nd/src/App.tsx
@@ -12,3 +12,5 @@ const App = () => (
 
 const root = ReactDOM.createRoot(document.getElementById("app") as HTMLElement);
 root.render(<App />);
+
+export default App;


### PR DESCRIPTION
## Summary
- export `App` component to make module federation work

## Testing
- `npm run build` *(fails: rspack permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6853661e16f88326a1cb0f9b0dbcd3d3